### PR TITLE
feat: allow uploading sboms as-is

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ DRV_PATH=$(nix-instantiate '<nixpkgs>' -A diffoscope)
 $ nix run git+https://codeberg.org/raboof/nix-build-sbom --no-write-lock-file -- $DRV_PATH --skip-without-deriver > build-closure-sbom.cdx.json
 $ export HASH_COLLECTION_TOKEN=XYX # your token
 $ JOBSET_ID=1 # replace with your jobset ID
-$ curl -X PUT "http://localhost:8000/api/jobsets/$JOBSET_ID/upload-evaluation" \
+$ curl -X PUT "http://localhost:8000/api/jobsets/$JOBSET_ID/upload-evaluation/$REV" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $HASH_COLLECTION_TOKEN" \
   --data @build-closure-sbom.cdx.json
@@ -111,7 +111,7 @@ $ nix-store -q --tree $(nix-build '<nixpkgs>' -A diffoscope) > /tmp/tree.txt
 $ cat /tmp/tree.txt | nix run git+https://codeberg.org/raboof/nix-runtime-tree-to-sbom --no-write-lock-file -- --skip-without-deriver --include-drv-paths-from /tmp/build-closure-sbom.cdx.json > /tmp/sbom.cdx.json
 $ export HASH_COLLECTION_TOKEN=XYX # your token
 $ JOBSET_ID=1 # replace with your jobset ID
-$ curl -X PUT "http://localhost:8000/api/jobsets/$JOBSET_ID/upload-evaluation" \
+$ curl -X PUT "http://localhost:8000/api/jobsets/$JOBSET_ID/upload-evaluation/$REV" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $HASH_COLLECTION_TOKEN" \
   --data @/tmp/sbom.cdx.json
@@ -124,16 +124,29 @@ ISO, they [no longer](https://github.com/NixOS/nixpkgs/pull/425700) show
 up as runtime dependencies. To get an evaluation for the derivations that go into
 a given installation ISO:
 
-Check out a 'clean' checkout of nixpkgs, notably not containing any files that would be ignored by git (you can check with `git status --ignored`) or empty directories (you can check with `find . -type d -empty`).
+Check out a 'clean' checkout of nixpkgs:
 
 ```
 $ cd /path/to/nixpkgs
+$ git status --ignored --short | tr -d \! | xargs rm
+$ find . -type d -empty -delete
+```
+
+Then:
+
+```
+$ REV=$(git log -1 --pretty=format:%h)
 $ DRV_PATH=$(nix-instantiate /path/to/lila/installation-iso-store-contents.nix --argstr nixpkgs-under-test $(pwd) --argstr version $(cat lib/.version) --argstr revCount $(git rev-list $(git log -1 --pretty=format:%h) | wc -l) --argstr shortRev $(git log -1 --pretty=format:%h) --argstr rev $(git rev-parse HEAD))
 $ nix run git+https://codeberg.org/raboof/nix-build-sbom --no-write-lock-file -- $DRV_PATH --skip-without-deriver --include-outputs all > /tmp/build-closure-sbom.cdx.json
 $ OUT_PATH=$(nix-build $DRV_PATH)
 $ nix-store -q --tree $OUT_PATH > /tmp/tree.txt
 $ cat /tmp/tree.txt | nix run git+https://codeberg.org/raboof/nix-runtime-tree-to-sbom --no-write-lock-file -- --skip-without-deriver --include-drv-paths-from /tmp/build-closure-sbom.cdx.json > /tmp/sbom.cdx.json
 $ export HASH_COLLECTION_TOKEN=XYX # your token
+$ export JOBSET_ID=XYX # the jobset this is part of
+$ curl -X PUT "http://localhost:8000/api/jobsets/$JOBSET_ID/upload-evaluation/$REV" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $HASH_COLLECTION_TOKEN" \
+  --data @/tmp/sbom.cdx.json
 ```
 
 #### Populating an evaluation

--- a/web/api/jobsets.py
+++ b/web/api/jobsets.py
@@ -83,30 +83,26 @@ def delete_jobset(
     return {"message": "Jobset deleted"}
 
 
-class EvaluationUpload(BaseModel):
-    git_revision: str
-    definition: dict
-
-
-@router.put("/{jobset_id}/upload-evaluation", response_model=schemas.EvaluationResponse)
+@router.put("/{jobset_id}/upload-evaluation/{git_revision}", response_model=schemas.EvaluationResponse)
 def upload_evaluation(
     jobset_id: int,
-    body: EvaluationUpload,
+    git_revision: str,
+    body: dict,
     user_id: int = Depends(get_user),
     db: Session = Depends(get_db),
 ):
     """Upload a new evaluation for a jobset"""
     # Check if evaluation with this revision already exists
-    existing = crud.get_evaluation_by_revision(db, jobset_id, body.git_revision)
+    existing = crud.get_evaluation_by_revision(db, jobset_id, git_revision)
     if existing:
         raise HTTPException(
             status_code=409,
-            detail=f"Evaluation with revision '{body.git_revision}' already exists for this jobset"
+            detail=f"Evaluation with revision '{git_revision}' already exists for this jobset"
         )
 
-    eval = crud.create_evaluation(db, jobset_id, body.git_revision, body.definition)
+    eval = crud.create_evaluation(db, jobset_id, git_revision, body)
     # parse the sbom and populate output path list
-    components = body.definition["components"]
+    components = body["components"]
     for component in components:
         out_path = None
         for prop in component["properties"]:

--- a/web/tests/test_api.py
+++ b/web/tests/test_api.py
@@ -377,8 +377,8 @@ class TestJobsetEndpoints:
             sbom = json.load(f)
 
         response = client.put(
-            f"/api/jobsets/{test_jobset['id']}/upload-evaluation",
-            json={"git_revision": "abc123def", "definition": sbom},
+            f"/api/jobsets/{test_jobset['id']}/upload-evaluation/abc123def",
+            json=sbom,
             headers={"Authorization": f"Bearer {test_user['token']}"}
         )
         assert response.status_code == 200
@@ -587,8 +587,8 @@ class TestEvalEndpoints:
         )
 
         response = client.put(
-            "/api/jobsets/1/upload-evaluation",
-            json={"git_revision": "test123rev", "definition": sbom},
+            "/api/jobsets/1/upload-evaluation/test123rev",
+            json=sbom,
             headers={"Authorization": f"Bearer {test_user['token']}"}
         )
 


### PR DESCRIPTION
by moving the revision/slug to the URL

we will likely want to have more metadata in the future (ideally enough for rebuilders to start rebuilding), but hopefully we can encode that in the SBOM itself, without 'wrapping' it - or otherwise use query parameters.